### PR TITLE
Fix typo in ImageButton docs

### DIFF
--- a/suit/docs/widgets.rst
+++ b/suit/docs/widgets.rst
@@ -65,7 +65,7 @@ is always computed from the ``normal`` image.
 
 .. note::
 
-  ``ImageButton`` does not recieve width and height parameters.  As such, it
+  ``ImageButton`` does not receive width and height parameters.  As such, it
   does not necessarily honor the cell size of a :doc:`layout`.
 
 .. note::


### PR DESCRIPTION
## Summary
- fix typo "recieve" -> "receive" in docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847085efda48330bf3c5196ca4c381b