### PR TITLE
Fix supernova angle calc

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -544,7 +544,7 @@ function applySupernovaEffect(x, y, explosionEnergy, sourceBody)
             local dist = math.sqrt(dx*dx + dy*dy)
             if dist < disturbanceRadius then
                 local forceMagnitude = (explosionEnergy / 10) * (1 - dist/disturbanceRadius)
-                local angle = math.atan2(dy, dx)
+                local angle = math.atan(dy, dx)
                 body.vx = body.vx + math.cos(angle) * forceMagnitude / body.mass
                 body.vy = body.vy + math.sin(angle) * forceMagnitude / body.mass
             end


### PR DESCRIPTION
## Summary
- fix call to `math.atan` for supernova explosion direction
- tried to run the game with LOVE2D but the container couldn't open an OpenGL window

## Testing
- `luac -p main.lua`
- `love .` *(fails: OpenGL window could not be created)*

------
https://chatgpt.com/codex/tasks/task_e_684708604db08330aaba8a983ec86e03